### PR TITLE
avr32: add sign extension in `trans_SUBc_f1`

### DIFF
--- a/target/avr32/translate.c
+++ b/target/avr32/translate.c
@@ -141,7 +141,7 @@ static bool decode_insn(DisasContext *ctx, uint32_t insn);
 #include "decode-insn.c.inc"
 
 static int sign_extend_8(int number){
-    if((number >> 7) == 1){
+    if(((number >> 7) & 1) == 1){
         number |= 0xFFFFFF00;
     }
     return number;
@@ -3968,7 +3968,9 @@ static bool trans_SUBc_f1(DisasContext *ctx, arg_SUBc_f1 *a){
 
     // if
     gen_set_label(if1);
-    tcg_gen_subi_i32(res, cpu_r[a->rd], a->imm8);
+    // See 32-bit Atmel Architecture Manual chapter 9.4 SUB{cond4} (page.358)
+    // https://ww1.microchip.com/downloads/en/devicedoc/doc32000.pdf
+    tcg_gen_subi_i32(res, cpu_r[a->rd], sign_extend_8(a->imm8));
     tcg_gen_mov_i32(rd, cpu_r[a->rd]);
     tcg_gen_movi_i32(k, sign_extend_8(a->imm8));
     tcg_gen_mov_i32(cpu_r[a->rd], res);


### PR DESCRIPTION
This commit fixes mistranslation while handling `SUB{cond4}` format I.

According to [32-bit Atmel Architecture Manual](https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/doc32000.pdf), `SUB{cond4}` format I should extend its source immediate value. (See section 9.3.2 table 9-2)
The manual has a typo in section 9.4 `SUB{cond4}` operation I that it does not extend `imm8` properly.
I've submitted a report to Atmel and receive confirmation about it.

This affects all branches except `master` and should be merged into them.