### PR TITLE
Fix gdbstub and add error message in illegal instruction helper

### DIFF
--- a/target/avr32/gdbstub.c
+++ b/target/avr32/gdbstub.c
@@ -46,10 +46,11 @@ int avr32_cpu_gdb_write_register(CPUState *cs, uint8_t *mem_buf, int n)
     printf("Writing GDB input to register %i", n);
 
     uint32_t val = 0;
-    val |= ((*mem_buf & 0x000000FF) << 24);
-    val |= ((*mem_buf & 0x0000FF00) << 8);
-    val |= ((*mem_buf & 0x00FF0000) >> 8);
-    val |= ((*mem_buf & 0xFF000000) >> 24);
+    uint32_t memval = (uint32_t)ldl_p(mem_buf);
+    val |= ((memval & 0x000000FF) << 24);
+    val |= ((memval & 0x0000FF00) << 8);
+    val |= ((memval & 0x00FF0000) >> 8);
+    val |= ((memval & 0xFF000000) >> 24);
     env->r[n] = val;
 
     return 0;

--- a/target/avr32/helper.c
+++ b/target/avr32/helper.c
@@ -23,6 +23,7 @@
 #include "tcg/tcg.h"
 #include "exec/helper-proto.h"
 #include "hw/avr32/boot.h"
+#include "qemu/qemu-print.h"
 
 static inline void raise_exception(CPUAVR32AState *env, int index,
         uintptr_t retaddr);
@@ -38,6 +39,7 @@ static inline G_NORETURN void raise_exception(CPUAVR32AState *env, int index,
 
 void helper_raise_illegal_instruction(CPUAVR32AState *env)
 {
+    qemu_fprintf(stderr, "[%s] Illegal instruction @ %#010x\n", __FUNCTION__, env->r[AVR32A_PC_REG]);
     raise_exception(env, 23, 0);
 }
 


### PR DESCRIPTION
This PR fixes misbehavior while updating register value via gdb.
The original implementation does not properly handle value stored in `mem_buf` so that register update such as `set $pc = 0xcafebabe` does not work.

Also, I've added an error message in `helper_raise_illegal_instruction` to explicitly notice illegal instruction signal.