### PR TITLE
fix: Change `cpu_sysr` to `cpu_sflags` in SCALL

### DIFF
--- a/target/avr32/translate.c
+++ b/target/avr32/translate.c
@@ -3283,10 +3283,10 @@ static bool trans_SCALL(DisasContext *ctx, arg_SCALL *a){
 
     TCGv sr_m = tcg_temp_new_i32();
     TCGv temp = tcg_temp_new_i32();
-    tcg_gen_shli_i32(sr_m, cpu_sysr[24], 2);
-    tcg_gen_shli_i32(temp, cpu_sysr[23], 1);
+    tcg_gen_shli_i32(sr_m, cpu_sflags[24], 2);
+    tcg_gen_shli_i32(temp, cpu_sflags[23], 1);
     tcg_gen_or_i32(sr_m, sr_m, temp);
-    tcg_gen_or_i32(sr_m, sr_m, cpu_sysr[22]);
+    tcg_gen_or_i32(sr_m, sr_m, cpu_sflags[22]);
 
 
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 0, if_1);
@@ -3304,8 +3304,7 @@ static bool trans_SCALL(DisasContext *ctx, arg_SCALL *a){
     tcg_gen_qemu_st_i32(temp, cpu_r[SP_REG], 0x0, MO_BEUL);
 
     for(int i= 0; i< 32; i++){
-        tcg_gen_mov_i32(temp, cpu_sflags[i]);
-        tcg_gen_shli_i32(sr, cpu_sflags[i], i);
+        tcg_gen_shli_i32(temp, cpu_sflags[i], i);
         tcg_gen_or_i32(sr, sr, cpu_sflags[i]);
     }
     tcg_gen_subi_i32(cpu_r[SP_REG], cpu_r[SP_REG], 0x4);
@@ -3321,7 +3320,7 @@ static bool trans_SCALL(DisasContext *ctx, arg_SCALL *a){
 
     // else
     gen_set_label(if_1_else);
-    tcg_gen_movi_i32(cpu_r[LR_REG], ctx->base.pc_next + 2);
+    tcg_gen_addi_i32(cpu_r[LR_REG], cpu_r[PC_REG], 0x2);
     tcg_gen_addi_i32(cpu_r[PC_REG], cpu_sysr[1], 0x100);
 
     gen_set_label(exit);


### PR DESCRIPTION
This is also a translation bug similar to #1.

According to [32-bit Atmel Architecture Manual](https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/doc32000.pdf), `SCALL` instruction checks the bits from status registers.
Its operation is as follow:
```
 If ( SR[M2:M0] == {B’000 or B’001} )
   ...
```

Status register, which is the first system register, is represented as `cpu_sflags` in current translation implementation.
In `trans_SCALL`, however, it translates `SR[M2:M0]` in the above if statement into `cpu_sysr[24]`, `cpu_sysr[23]`, and `cpu_sysr[22]` which are `JAVA_LV1`, `JAVA_LV0`, and `JOSP` respectively.
They should be `cpu_sflags` or bit slice from `cpu_sysr[0]`.
Since current implementation does not synchronize `cpu_sysr[0]` with `cpu_sflags`, I've used `cpu_sflags` to maintain consistency.
