### PR TITLE
fix: Modify status register initial value

### DIFF
--- a/target/avr32/cpu.c
+++ b/target/avr32/cpu.c
@@ -108,6 +108,13 @@ static void avr32_cpu_reset(DeviceState *dev)
         env->sysr[i] = 0;
     }
 
+    // sflags == sr == sysr[0]
+    // 16: GM
+    // 21: EM
+    // 22: M0
+    env->sr = (1 << 16) | (1 << 21) | (1 << 22);
+    env->sysr[0] = env->sr;
+
     for(int i= 0; i< AVR32A_REG_PAGE_SIZE; i++){
         env->r[i] = 0;
     }

--- a/target/avr32/cpu.h
+++ b/target/avr32/cpu.h
@@ -105,7 +105,8 @@ int avr32_print_insn(bfd_vma addr, disassemble_info *info);
 
 static inline int cpu_interrupts_enabled(CPUAVR32AState* env)
 {
-    return AVR32_GM_FLAG(env->sr);
+    // Only check GM bit for now...
+    return (env->sflags[16] == 0);
 }
 
 static inline int cpu_mmu_index(CPUAVR32AState *env, bool ifetch)


### PR DESCRIPTION
Current implementation uses 3 representation of status register: `sr`, `sflags`, and `sysr[0]`
`sr` is used to check whether global interrupt mask is set in `cpu_interrupts_enabled`.
`sflags` is used in TCG translation and dumping CPU registers.
`sysr[0]` is status register by definition, but it is not used to handle status register related operations.

According to [32-bit Atmel Architecture Manual](https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/doc32000.pdf) section 2.10, status register should set GM, EM, and M0 bit at initial state.
Currently, each `sflags` is set, but `sr` and `sysr[0]` start with 0.
Therefore, it result in behavior mismatch while emulating since `cpu_interrupts_enabled` refers `sr`.
Also, cpu interrupts are **disabled** when GM bit is set accroding to architecture manual.

TODO: Current design makes confusion in further development.
All 3 status registers should have exactly same value because they are aliases.
It would be better to modify all status register related code to use `sysr[0]` without alias.
For example, add a macro wrapper to access lower 16 bit flags or each flag bit from `sysr[0]`.