### PR TITLE
fix: Add missing check for `RETE`

### DIFF
--- a/target/avr32/translate.c
+++ b/target/avr32/translate.c
@@ -2901,6 +2901,7 @@ static bool trans_RETE(DisasContext *ctx, arg_RETE *a){
     // Check if SR[M2:M0] >= 001
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 2, if_1);
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 3, if_1);
+    tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 4, if_1);
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 5, if_1);
     tcg_gen_br(exit);
 


### PR DESCRIPTION
According to [32-bit Atmel Architecture Manual](https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/doc32000.pdf), `RETE` instruction checks whether M2:M0 bits in status register is equal to `010`, `011`, `100`, and `101`.
Current implementation does not check whether M2:M0 is equal to `100`.