### PR TITLE
fix: Fix reset address

### DIFF
--- a/target/avr32/cpu.c
+++ b/target/avr32/cpu.c
@@ -114,7 +114,7 @@ static void avr32_cpu_reset(DeviceState *dev)
 
     printf("RESET 2\n");
 
-    env->r[AVR32A_PC_REG] = 0xd0000000;
+    env->r[AVR32A_PC_REG] = 0x80000000;
     env->r[AVR32A_LR_REG] = 0;
     env->r[AVR32A_SP_REG] = 0;
 }


### PR DESCRIPTION
According to [32-bit Atmel Architecture Manual](https://ww1.microchip.com/downloads/aemDocuments/documents/OTH/ProductDocuments/DataSheets/doc32000.pdf) section 8.3, AVR32A places the reset routine at `0x8000_0000`.
This fixes the initial value of PC when cpu has been reset.