### PR TITLE
fix: Fix loader and memory map

### DIFF
--- a/hw/avr32/boot.c
+++ b/hw/avr32/boot.c
@@ -28,129 +28,6 @@
 #include "exec/exec-all.h"
 #include "target/avr32/helper_elf.h"
 
-void avr32_copy_text_section(int e_shnum, FILE* file, Elf32_Shdr** sh_table, char *sh_strtable, FILE* output){
-    int text_section_idx = -1;
-    for(int i= 0; i< e_shnum; i++){
-        if(strcmp(&sh_strtable[sh_table[i]->sh_name], ".text") == 0){
-            text_section_idx = i;
-            break;
-        }
-    }
-    if(text_section_idx >= 0){
-        printf("[AVR32-BOOT] Text section is at index %i\n", text_section_idx);
-    }
-    else{
-        error_report("[AVR32-BOOT] Unable to find .text section!\n");
-        exit(1);
-    }
-
-    char *buffer = malloc(sh_table[text_section_idx]->sh_size);
-    fseek(file, sh_table[text_section_idx]->sh_offset, SEEK_SET);
-    int res = fread(buffer, 1, sh_table[text_section_idx]->sh_size, file);
-    printf("[AVR32-BOOT] Loaded 0x%x bytes from .text section\n", res);
-    fwrite(buffer, 1, res, output);
-    free(buffer);
-}
-
-void avr32_copy_data_section(int e_shnum, FILE* file, Elf32_Shdr** sh_table, char *sh_strtable, FILE* output){
-    int data_section_idx = -1;
-    for(int i= 0; i< e_shnum; i++){
-        if(strcmp(&sh_strtable[sh_table[i]->sh_name], ".data") == 0){
-            data_section_idx = i;
-            break;
-        }
-    }
-    if(data_section_idx >= 0){
-        printf("[AVR32-BOOT] Data section is at index %i\n", data_section_idx);
-    }
-    else{
-        error_report("[AVR32-BOOT] Unable to find .data section.\n");
-        return;
-    }
-    if(sh_table[data_section_idx]->sh_size <= 0){
-        printf("[AVR32-BOOT] Data section has size 0, skipping.\n");
-        return;
-    }
-    int padding_size = sh_table[data_section_idx]->sh_offset - (sh_table[data_section_idx - 1]->sh_offset + sh_table[data_section_idx - 1]->sh_size) - sh_table[data_section_idx]->sh_addr;
-    printf("[AVR32-BOOT] Data section padding size: 0x%x\n", padding_size);
-    char *buffer = malloc(padding_size);
-    memset(buffer, 0, padding_size);
-    fwrite(buffer, 1, padding_size, output);
-    free(buffer);
-
-    buffer = malloc(sh_table[data_section_idx]->sh_size);
-    fseek(file, sh_table[data_section_idx]->sh_offset, SEEK_SET);
-    int res = fread(buffer, 1, sh_table[data_section_idx]->sh_size, file);
-    printf("[AVR32-BOOT] Loaded 0x%x bytes from .data section\n", res);
-    fwrite(buffer, 1, res, output);
-    free(buffer);
-}
-
-void avr32_copy_sections(int e_shnum, FILE* file, Elf32_Shdr** sh_table, char *sh_strtable, MemoryRegion *program_mr){
-    FILE *output = fopen("/tmp/qemu_avr32_tmp_text_sec", "wb");
-    avr32_copy_text_section(e_shnum, file, sh_table, sh_strtable, output);
-    avr32_copy_data_section(e_shnum, file, sh_table, sh_strtable, output);
-    fclose(output);
-
-
-    int bytes_loaded = load_image_mr("/tmp/qemu_avr32_tmp_text_sec", program_mr);
-    if (bytes_loaded < 0) {
-        error_report("[AVR32-BOOT] Unable to load firmware image %s as raw binary",
-                     "/tmp/qemu_avr32_tmp_text_sec");
-        exit(1);
-    }
-    printf("[AVR32-BOOT] Binary data successfully loaded\n");
-    remove("/tmp/qemu_avr32_tmp_text_sec");
-    printf("[AVR32-BOOT] Removed temp firmware file\n");
-}
-
-bool avr32_load_elf_file(AVR32ACPU *cpu, const char *filename, MemoryRegion *program_mr){
-    printf("[AVR32-BOOT] Loading firmware images as ELF file\n");
-
-    Elf32_Ehdr header;
-    FILE* file = fopen(filename, "rb");
-    char *sh_strtable = 0;
-    Elf32_Shdr** sh_table = 0;
-    if(file) {
-        // read the header
-        int res = fread(&header, 1, sizeof(header), file);
-
-        if(res <= 0){
-            error_report("[AVR32-BOOT] Cannot read firmware image header\n");
-            exit(1);
-        }
-        // check if it's really an elf file
-        if (memcmp(header.e_ident, ELFMAG, SELFMAG) == 0) {
-            avr32_convert_elf_header(&header);
-            if(header.e_machine == EM_AVR32){
-                sh_table = malloc(header.e_shnum * sizeof (Elf32_Shdr*));
-
-                avr32_elf_read_section_headers(&header, file, sh_table);
-                sh_strtable = (char *)malloc(sh_table[header.e_shstrndx]->sh_size * sizeof(char));
-
-                avr32_elf_read_sh_string_table(&header, file, sh_table, sh_strtable);
-                avr32_copy_sections(header.e_shnum, file, sh_table, sh_strtable, program_mr);
-
-            }
-            else{
-                error_report("[AVR32-BOOT] Firmware file is not an AVR32 file!\n");
-            }
-        }
-        else{
-            error_report("[AVR32-BOOT] ELF file is not valid!\n");
-            exit(1);
-        }
-    }
-
-    fclose(file);
-    free(sh_strtable);
-    for(int i= 0; i< header.e_shnum; i++){
-        free(sh_table[i]);
-    }
-    free(sh_table);
-    return true;
-}
-
 bool avr32_load_firmware(AVR32ACPU *cpu, MachineState *ms,
                          MemoryRegion *program_mr, const char *firmware)
 {
@@ -160,13 +37,19 @@ bool avr32_load_firmware(AVR32ACPU *cpu, MachineState *ms,
         return false;
     }
 
-    if(avr32_is_elf_file(AVR32_FIRMWARE_FILE)){
-        //TODO: For some reason QEMU internal ELF-loaders fail to load an AVR32 Elf file. For now we use a custom elf-loader to extract the .text section from an elf-file.
-        avr32_load_elf_file(cpu, AVR32_FIRMWARE_FILE, program_mr);
-    }
-    else{
+    int bytes_loaded;
+    uint64_t entry;
+    uint32_t e_flags;
+    bytes_loaded = load_elf_ram_sym(AVR32_FIRMWARE_FILE,
+                                    NULL, NULL, NULL,
+                                    &entry, NULL, NULL,
+                                    &e_flags, true, EM_AVR32, 0, 0, // EM_AVR32: 185
+                                    NULL, true, NULL);
+    if (bytes_loaded >= 0) {
+
+    } else {
         printf("[AVR32-BOOT]: Loading firmware images as raw binary\n");
-        int bytes_loaded = load_image_mr(AVR32_FIRMWARE_FILE, program_mr);
+        bytes_loaded = load_image_mr(AVR32_FIRMWARE_FILE, program_mr);
         if (bytes_loaded < 0) {
             error_report("[AVR32-BOOT] Unable to load firmware image %s as raw binary",
                          firmware);

--- a/hw/avr32/nanomind_a3200.c
+++ b/hw/avr32/nanomind_a3200.c
@@ -147,7 +147,7 @@ static void nanomind_3200_init(MachineState *machine)
 
     if (machine->firmware) {
         if (!avr32_load_firmware(&nmms->soc.cpu.cpu, machine,
-                                 &nmms->soc.sdram, machine->firmware)) {
+                                 &nmms->soc.onChipFlash, machine->firmware)) {
             exit(1);
         }
     }

--- a/target/avr32/cpu.c
+++ b/target/avr32/cpu.c
@@ -114,7 +114,7 @@ static void avr32_cpu_reset(DeviceState *dev)
 
     printf("RESET 2\n");
 
-    env->r[AVR32A_PC_REG] = 0xd0000000;
+    env->r[AVR32A_PC_REG] = 0x80000000;
     env->r[AVR32A_LR_REG] = 0;
     env->r[AVR32A_SP_REG] = 0;
 }

--- a/target/avr32/cpu.c
+++ b/target/avr32/cpu.c
@@ -108,6 +108,13 @@ static void avr32_cpu_reset(DeviceState *dev)
         env->sysr[i] = 0;
     }
 
+    // sflags == sr == sysr[0]
+    // 16: GM
+    // 21: EM
+    // 22: M0
+    env->sr = (1 << 16) | (1 << 21) | (1 << 22);
+    env->sysr[0] = env->sr;
+
     for(int i= 0; i< AVR32A_REG_PAGE_SIZE; i++){
         env->r[i] = 0;
     }

--- a/target/avr32/cpu.c
+++ b/target/avr32/cpu.c
@@ -164,10 +164,26 @@ static void avr32_cpu_set_pc(CPUState *cs, vaddr value)
     cpu->env.r[AVR32A_PC_REG] = value;
 }
 
+static vaddr avr32_cpu_get_pc(CPUState *cs)
+{
+    AVR32ACPU *cpu = AVR32A_CPU(cs);
+    return cpu->env.r[AVR32A_PC_REG];
+}
+
 static bool avr32_cpu_exec_interrupt(CPUState *cs, int interrupt_request)
 {
     //TODO: Later
     return false;
+}
+
+static void avr32_restore_state_to_opc(CPUState *cs,
+                                     const TranslationBlock *tb,
+                                     const uint64_t *data)
+{
+    AVR32ACPU *cpu = AVR32A_CPU(cs);
+
+    // TODO: verify whether this is correct...
+    cpu->env.r[AVR32A_PC_REG] = data[0];
 }
 
 #include "hw/core/sysemu-cpu-ops.h"
@@ -179,6 +195,7 @@ static const struct SysemuCPUOps avr32_sysemu_ops = {
 static const struct TCGCPUOps avr32_tcg_ops = {
         .initialize = avr32_tcg_init,
         .synchronize_from_tb = avr32_cpu_synchronize_from_tb,
+        .restore_state_to_opc = avr32_restore_state_to_opc,
         .cpu_exec_interrupt = avr32_cpu_exec_interrupt,
         .tlb_fill = avr32_cpu_tlb_fill,
         .do_interrupt = avr32_cpu_do_interrupt,
@@ -204,6 +221,7 @@ static void avr32a_cpu_class_init(ObjectClass *oc, void *data)
     cc->has_work = avr32_cpu_has_work;
     cc->dump_state = avr32_cpu_dump_state;
     cc->set_pc = avr32_cpu_set_pc;
+    cc->get_pc = avr32_cpu_get_pc;
     cc->memory_rw_debug = avr32_cpu_memory_rw_debug;
     cc->sysemu_ops = &avr32_sysemu_ops;
     cc->disas_set_info = avr32_cpu_disas_set_info;

--- a/target/avr32/cpu.h
+++ b/target/avr32/cpu.h
@@ -105,7 +105,8 @@ int avr32_print_insn(bfd_vma addr, disassemble_info *info);
 
 static inline int cpu_interrupts_enabled(CPUAVR32AState* env)
 {
-    return AVR32_GM_FLAG(env->sr);
+    // Only check GM bit for now...
+    return (env->sflags[16] == 0);
 }
 
 static inline int cpu_mmu_index(CPUAVR32AState *env, bool ifetch)

--- a/target/avr32/gdbstub.c
+++ b/target/avr32/gdbstub.c
@@ -46,10 +46,11 @@ int avr32_cpu_gdb_write_register(CPUState *cs, uint8_t *mem_buf, int n)
     printf("Writing GDB input to register %i", n);
 
     uint32_t val = 0;
-    val |= ((*mem_buf & 0x000000FF) << 24);
-    val |= ((*mem_buf & 0x0000FF00) << 8);
-    val |= ((*mem_buf & 0x00FF0000) >> 8);
-    val |= ((*mem_buf & 0xFF000000) >> 24);
+    uint32_t memval = (uint32_t)ldl_p(mem_buf);
+    val |= ((memval & 0x000000FF) << 24);
+    val |= ((memval & 0x0000FF00) << 8);
+    val |= ((memval & 0x00FF0000) >> 8);
+    val |= ((memval & 0xFF000000) >> 24);
     env->r[n] = val;
 
     return 0;

--- a/target/avr32/helper.c
+++ b/target/avr32/helper.c
@@ -23,6 +23,7 @@
 #include "tcg/tcg.h"
 #include "exec/helper-proto.h"
 #include "hw/avr32/boot.h"
+#include "qemu/qemu-print.h"
 
 static inline void raise_exception(CPUAVR32AState *env, int index,
         uintptr_t retaddr);
@@ -38,6 +39,7 @@ static inline G_NORETURN void raise_exception(CPUAVR32AState *env, int index,
 
 void helper_raise_illegal_instruction(CPUAVR32AState *env)
 {
+    qemu_fprintf(stderr, "[%s] Illegal instruction @ %#010x\n", __FUNCTION__, env->r[AVR32A_PC_REG]);
     raise_exception(env, 23, 0);
 }
 

--- a/target/avr32/translate.c
+++ b/target/avr32/translate.c
@@ -3283,10 +3283,10 @@ static bool trans_SCALL(DisasContext *ctx, arg_SCALL *a){
 
     TCGv sr_m = tcg_temp_new_i32();
     TCGv temp = tcg_temp_new_i32();
-    tcg_gen_shli_i32(sr_m, cpu_sysr[24], 2);
-    tcg_gen_shli_i32(temp, cpu_sysr[23], 1);
+    tcg_gen_shli_i32(sr_m, cpu_sflags[24], 2);
+    tcg_gen_shli_i32(temp, cpu_sflags[23], 1);
     tcg_gen_or_i32(sr_m, sr_m, temp);
-    tcg_gen_or_i32(sr_m, sr_m, cpu_sysr[22]);
+    tcg_gen_or_i32(sr_m, sr_m, cpu_sflags[22]);
 
 
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 0, if_1);
@@ -3304,8 +3304,7 @@ static bool trans_SCALL(DisasContext *ctx, arg_SCALL *a){
     tcg_gen_qemu_st_i32(temp, cpu_r[SP_REG], 0x0, MO_BEUL);
 
     for(int i= 0; i< 32; i++){
-        tcg_gen_mov_i32(temp, cpu_sflags[i]);
-        tcg_gen_shli_i32(sr, cpu_sflags[i], i);
+        tcg_gen_shli_i32(temp, cpu_sflags[i], i);
         tcg_gen_or_i32(sr, sr, cpu_sflags[i]);
     }
     tcg_gen_subi_i32(cpu_r[SP_REG], cpu_r[SP_REG], 0x4);
@@ -3321,7 +3320,7 @@ static bool trans_SCALL(DisasContext *ctx, arg_SCALL *a){
 
     // else
     gen_set_label(if_1_else);
-    tcg_gen_movi_i32(cpu_r[LR_REG], ctx->base.pc_next + 2);
+    tcg_gen_addi_i32(cpu_r[LR_REG], cpu_r[PC_REG], 0x2);
     tcg_gen_addi_i32(cpu_r[PC_REG], cpu_sysr[1], 0x100);
 
     gen_set_label(exit);

--- a/target/avr32/translate.c
+++ b/target/avr32/translate.c
@@ -2901,6 +2901,7 @@ static bool trans_RETE(DisasContext *ctx, arg_RETE *a){
     // Check if SR[M2:M0] >= 001
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 2, if_1);
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 3, if_1);
+    tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 4, if_1);
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 5, if_1);
     tcg_gen_br(exit);
 

--- a/target/avr32/translate.c
+++ b/target/avr32/translate.c
@@ -141,7 +141,7 @@ static bool decode_insn(DisasContext *ctx, uint32_t insn);
 #include "decode-insn.c.inc"
 
 static int sign_extend_8(int number){
-    if((number >> 7) == 1){
+    if(((number >> 7) & 1) == 1){
         number |= 0xFFFFFF00;
     }
     return number;
@@ -3968,7 +3968,9 @@ static bool trans_SUBc_f1(DisasContext *ctx, arg_SUBc_f1 *a){
 
     // if
     gen_set_label(if1);
-    tcg_gen_subi_i32(res, cpu_r[a->rd], a->imm8);
+    // See 32-bit Atmel Architecture Manual chapter 9.4 SUB{cond4} (page.358)
+    // https://ww1.microchip.com/downloads/en/devicedoc/doc32000.pdf
+    tcg_gen_subi_i32(res, cpu_r[a->rd], sign_extend_8(a->imm8));
     tcg_gen_mov_i32(rd, cpu_r[a->rd]);
     tcg_gen_movi_i32(k, sign_extend_8(a->imm8));
     tcg_gen_mov_i32(cpu_r[a->rd], res);


### PR DESCRIPTION
Current custom ELF loader does not fully load sections in ELF file.
It results in emulation failure since default ELF from NanoMind A3200 BSP.
I have replaced the ELF loader with QEMU internal one without any errors.
Also, I've fixed the memory map address for firmware while loading firmware as a raw binary.
(It might be incorrect since I didn't test raw loader)

Tested on NanoMind A3200 BSP release 2.5.2