### PR TITLE
fix: Fix mpu3300 i2caddr

### DIFF
--- a/hw/avr32/nanomind_a3200.c
+++ b/hw/avr32/nanomind_a3200.c
@@ -108,7 +108,7 @@ static void nanomind_3200_init(MachineState *machine)
 
     // NanoMind Internal I2C
     // 3 Axis Gyroscope
-    dev = DEVICE(i2c_slave_create_simple(nmms->soc.twim[2].bus, "mpu3300", 0x69));
+    dev = DEVICE(i2c_slave_create_simple(nmms->soc.twim[2].bus, "mpu3300", 0x68));
     (void) dev;
     // 3 Axis Compass
     dev = DEVICE(i2c_slave_create_simple(nmms->soc.twim[2].bus, "hmc5843", 0x1e));

--- a/target/avr32/cpu.c
+++ b/target/avr32/cpu.c
@@ -114,7 +114,7 @@ static void avr32_cpu_reset(DeviceState *dev)
 
     printf("RESET 2\n");
 
-    env->r[AVR32A_PC_REG] = 0xd0000000;
+    env->r[AVR32A_PC_REG] = 0x80000000;
     env->r[AVR32A_LR_REG] = 0;
     env->r[AVR32A_SP_REG] = 0;
 }

--- a/target/avr32/cpu.c
+++ b/target/avr32/cpu.c
@@ -108,6 +108,13 @@ static void avr32_cpu_reset(DeviceState *dev)
         env->sysr[i] = 0;
     }
 
+    // sflags == sr == sysr[0]
+    // 16: GM
+    // 21: EM
+    // 22: M0
+    env->sr = (1 << 16) | (1 << 21) | (1 << 22);
+    env->sysr[0] = env->sr;
+
     for(int i= 0; i< AVR32A_REG_PAGE_SIZE; i++){
         env->r[i] = 0;
     }

--- a/target/avr32/cpu.c
+++ b/target/avr32/cpu.c
@@ -164,10 +164,26 @@ static void avr32_cpu_set_pc(CPUState *cs, vaddr value)
     cpu->env.r[AVR32A_PC_REG] = value;
 }
 
+static vaddr avr32_cpu_get_pc(CPUState *cs)
+{
+    AVR32ACPU *cpu = AVR32A_CPU(cs);
+    return cpu->env.r[AVR32A_PC_REG];
+}
+
 static bool avr32_cpu_exec_interrupt(CPUState *cs, int interrupt_request)
 {
     //TODO: Later
     return false;
+}
+
+static void avr32_restore_state_to_opc(CPUState *cs,
+                                     const TranslationBlock *tb,
+                                     const uint64_t *data)
+{
+    AVR32ACPU *cpu = AVR32A_CPU(cs);
+
+    // TODO: verify whether this is correct...
+    cpu->env.r[AVR32A_PC_REG] = data[0];
 }
 
 #include "hw/core/sysemu-cpu-ops.h"
@@ -179,6 +195,7 @@ static const struct SysemuCPUOps avr32_sysemu_ops = {
 static const struct TCGCPUOps avr32_tcg_ops = {
         .initialize = avr32_tcg_init,
         .synchronize_from_tb = avr32_cpu_synchronize_from_tb,
+        .restore_state_to_opc = avr32_restore_state_to_opc,
         .cpu_exec_interrupt = avr32_cpu_exec_interrupt,
         .tlb_fill = avr32_cpu_tlb_fill,
         .do_interrupt = avr32_cpu_do_interrupt,
@@ -204,6 +221,7 @@ static void avr32a_cpu_class_init(ObjectClass *oc, void *data)
     cc->has_work = avr32_cpu_has_work;
     cc->dump_state = avr32_cpu_dump_state;
     cc->set_pc = avr32_cpu_set_pc;
+    cc->get_pc = avr32_cpu_get_pc;
     cc->memory_rw_debug = avr32_cpu_memory_rw_debug;
     cc->sysemu_ops = &avr32_sysemu_ops;
     cc->disas_set_info = avr32_cpu_disas_set_info;

--- a/target/avr32/cpu.h
+++ b/target/avr32/cpu.h
@@ -105,7 +105,8 @@ int avr32_print_insn(bfd_vma addr, disassemble_info *info);
 
 static inline int cpu_interrupts_enabled(CPUAVR32AState* env)
 {
-    return AVR32_GM_FLAG(env->sr);
+    // Only check GM bit for now...
+    return (env->sflags[16] == 0);
 }
 
 static inline int cpu_mmu_index(CPUAVR32AState *env, bool ifetch)

--- a/target/avr32/gdbstub.c
+++ b/target/avr32/gdbstub.c
@@ -46,10 +46,11 @@ int avr32_cpu_gdb_write_register(CPUState *cs, uint8_t *mem_buf, int n)
     printf("Writing GDB input to register %i", n);
 
     uint32_t val = 0;
-    val |= ((*mem_buf & 0x000000FF) << 24);
-    val |= ((*mem_buf & 0x0000FF00) << 8);
-    val |= ((*mem_buf & 0x00FF0000) >> 8);
-    val |= ((*mem_buf & 0xFF000000) >> 24);
+    uint32_t memval = (uint32_t)ldl_p(mem_buf);
+    val |= ((memval & 0x000000FF) << 24);
+    val |= ((memval & 0x0000FF00) << 8);
+    val |= ((memval & 0x00FF0000) >> 8);
+    val |= ((memval & 0xFF000000) >> 24);
     env->r[n] = val;
 
     return 0;

--- a/target/avr32/helper.c
+++ b/target/avr32/helper.c
@@ -23,6 +23,7 @@
 #include "tcg/tcg.h"
 #include "exec/helper-proto.h"
 #include "hw/avr32/boot.h"
+#include "qemu/qemu-print.h"
 
 static inline void raise_exception(CPUAVR32AState *env, int index,
         uintptr_t retaddr);
@@ -38,6 +39,7 @@ static inline G_NORETURN void raise_exception(CPUAVR32AState *env, int index,
 
 void helper_raise_illegal_instruction(CPUAVR32AState *env)
 {
+    qemu_fprintf(stderr, "[%s] Illegal instruction @ %#010x\n", __FUNCTION__, env->r[AVR32A_PC_REG]);
     raise_exception(env, 23, 0);
 }
 

--- a/target/avr32/translate.c
+++ b/target/avr32/translate.c
@@ -3283,10 +3283,10 @@ static bool trans_SCALL(DisasContext *ctx, arg_SCALL *a){
 
     TCGv sr_m = tcg_temp_new_i32();
     TCGv temp = tcg_temp_new_i32();
-    tcg_gen_shli_i32(sr_m, cpu_sysr[24], 2);
-    tcg_gen_shli_i32(temp, cpu_sysr[23], 1);
+    tcg_gen_shli_i32(sr_m, cpu_sflags[24], 2);
+    tcg_gen_shli_i32(temp, cpu_sflags[23], 1);
     tcg_gen_or_i32(sr_m, sr_m, temp);
-    tcg_gen_or_i32(sr_m, sr_m, cpu_sysr[22]);
+    tcg_gen_or_i32(sr_m, sr_m, cpu_sflags[22]);
 
 
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 0, if_1);
@@ -3304,8 +3304,7 @@ static bool trans_SCALL(DisasContext *ctx, arg_SCALL *a){
     tcg_gen_qemu_st_i32(temp, cpu_r[SP_REG], 0x0, MO_BEUL);
 
     for(int i= 0; i< 32; i++){
-        tcg_gen_mov_i32(temp, cpu_sflags[i]);
-        tcg_gen_shli_i32(sr, cpu_sflags[i], i);
+        tcg_gen_shli_i32(temp, cpu_sflags[i], i);
         tcg_gen_or_i32(sr, sr, cpu_sflags[i]);
     }
     tcg_gen_subi_i32(cpu_r[SP_REG], cpu_r[SP_REG], 0x4);
@@ -3321,7 +3320,7 @@ static bool trans_SCALL(DisasContext *ctx, arg_SCALL *a){
 
     // else
     gen_set_label(if_1_else);
-    tcg_gen_movi_i32(cpu_r[LR_REG], ctx->base.pc_next + 2);
+    tcg_gen_addi_i32(cpu_r[LR_REG], cpu_r[PC_REG], 0x2);
     tcg_gen_addi_i32(cpu_r[PC_REG], cpu_sysr[1], 0x100);
 
     gen_set_label(exit);

--- a/target/avr32/translate.c
+++ b/target/avr32/translate.c
@@ -2901,6 +2901,7 @@ static bool trans_RETE(DisasContext *ctx, arg_RETE *a){
     // Check if SR[M2:M0] >= 001
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 2, if_1);
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 3, if_1);
+    tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 4, if_1);
     tcg_gen_brcondi_i32(TCG_COND_EQ, sr_m, 5, if_1);
     tcg_gen_br(exit);
 

--- a/target/avr32/translate.c
+++ b/target/avr32/translate.c
@@ -141,7 +141,7 @@ static bool decode_insn(DisasContext *ctx, uint32_t insn);
 #include "decode-insn.c.inc"
 
 static int sign_extend_8(int number){
-    if((number >> 7) == 1){
+    if(((number >> 7) & 1) == 1){
         number |= 0xFFFFFF00;
     }
     return number;
@@ -3968,7 +3968,9 @@ static bool trans_SUBc_f1(DisasContext *ctx, arg_SUBc_f1 *a){
 
     // if
     gen_set_label(if1);
-    tcg_gen_subi_i32(res, cpu_r[a->rd], a->imm8);
+    // See 32-bit Atmel Architecture Manual chapter 9.4 SUB{cond4} (page.358)
+    // https://ww1.microchip.com/downloads/en/devicedoc/doc32000.pdf
+    tcg_gen_subi_i32(res, cpu_r[a->rd], sign_extend_8(a->imm8));
     tcg_gen_mov_i32(rd, cpu_r[a->rd]);
     tcg_gen_movi_i32(k, sign_extend_8(a->imm8));
     tcg_gen_mov_i32(cpu_r[a->rd], res);


### PR DESCRIPTION
According to NanoMind A3200 BSP (relase 2.5.2), MPU3300 uses I2C address as `0x68`, not `0x69`